### PR TITLE
THREESCALE-10731 add a db setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Readme 3scale-perf-setup
+
+As series of scripts to automate preparing a cluster for Performance Testing
+- Databases
+
+# Usage
+## Databases Setup
+chmod and run the script against a fresh cluster
+```bash
+chmod 771 setup_db.sh
+./setup_db.sh
+```

--- a/setup_db.sh
+++ b/setup_db.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+# Prereq: 
+# oc, openshift cluster, ssh keys setup for github, operator-sdk, go1.19
+
+# Usage : 
+# chmod 771 setup_db.sh
+# ./setup_db.sh
+
+# Outcome: 
+# CRO will create three redis and one posgres and secrets pointing to these db will be created in the 3scale-test ns
+
+
+# Function to check if redis CR is available
+check_redis_available() {
+    local message=$(oc get redis "$1" -o jsonpath="{.status.message}")
+    if [[ "$message" == *"redis deployment available"* ]]; then
+        return 0  # Redis CR is available
+    else
+        return 1  # Redis CR is not available
+    fi
+}
+
+# Function to check if redis CR phase is complete
+check_redis_complete() {
+    local phase=$(oc get redis "$1" -o jsonpath="{.status.phase}")
+    if [[ "$phase" == "complete" ]]; then
+        return 0  # Redis CR phase is complete
+    else
+        return 1  # Redis CR phase is not complete
+    fi
+}
+
+# Function to check if postgres CR is available
+check_postgres_available() {
+    local message=$(oc get postgres example-postgres -o jsonpath="{.status.message}")
+    if [[ "$message" == *"creation successful"* ]]; then
+        return 0  # Postgres CR is available
+    else
+        return 1  # Postgres CR is not available
+    fi
+}
+
+# Function to check if postgres CR phase is complete
+check_postgres_complete() {
+    local phase=$(oc get postgres example-postgres -o jsonpath="{.status.phase}")
+    if [[ "$phase" == "complete" ]]; then
+        return 0  # Postgres CR phase is complete
+    else
+        return 1  # Postgres CR phase is not complete
+    fi
+}
+
+
+git clone git@github.com:integr8ly/cloud-resource-operator.git
+cd cloud-resource-operator
+make cluster/prepare
+REDIS_NAME=redis-storage make cluster/seed/redis
+REDIS_NAME=redis-queue make cluster/seed/redis
+REDIS_NAME=redis-system make cluster/seed/redis
+make cluster/seed/postgres
+
+RECTIME=30 WATCH_NAMESPACE=cloud-resource-operator go run ./main.go &>/dev/null &
+
+# Check postgres is completed
+while true; do
+    if check_postgres_available && check_postgres_complete; then
+        echo "Both postgres conditions are satisfied for example-postgres. Proceeding with the script."
+        break  # Exit the loop when both conditions are satisfied
+    else
+        echo "One or both postgres conditions are not satisfied for example-postgres. Retrying in 10 seconds."
+        sleep 10  # Wait for 10 seconds before retrying
+    fi
+done
+# Check all redis are completed
+redis_variables=("redis-storage" "redis-queue" "redis-system")
+
+for var in "${redis_variables[@]}"; do
+    while true; do
+        if check_redis_available "$var" && check_redis_complete "$var"; then
+            echo "Both redis conditions are satisfied for $var. Proceeding with the script."
+            break  # Exit the loop when both conditions are satisfied
+        else
+            echo "One or both conditions are not satisfied for $var. Retrying in 10 seconds."
+            sleep 10  # Wait for 10 seconds before retrying
+        fi
+    done
+done
+
+                                                      
+# Kill the operator process
+pkill -f "main.go"
+# delete the cloud-resources-operator dir
+cd ..
+rm -rf cloud-resources-operator
+
+
+# create the 3scale namespace
+oc new-project 3scale-test
+
+# Creating secrets in the 3scale-test namespace
+echo Creating secrets in the 3scale-test namespace
+oc create secret generic system-redis \
+    --from-literal=URL=redis://redis-system.cloud-resource-operator.svc.cluster.local:6379 \
+    --namespace=3scale-test
+oc create secret generic backend-redis \
+    --from-literal=REDIS_QUEUES_URL=redis://redis-queue.cloud-resource-operator.svc.cluster.local:6379 \
+    --from-literal=REDIS_STORAGE_URL=redis://redis-queue.cloud-resource-operator.svc.cluster.local:6379 \
+    --namespace=3scale-test
+
+PASSWORD=$(oc get secret example-postgres-sec -n cloud-resource-operator -o jsonpath="{.data.password}" | base64 -d)
+HOST=$(oc get secret example-postgres-sec -n cloud-resource-operator -o jsonpath="{.data.host}" | base64 -d)
+DATABASE=$(oc get secret example-postgres-sec -n cloud-resource-operator -o jsonpath="{.data.database}" | base64 -d)
+USERNAME=$(oc get secret example-postgres-sec -n cloud-resource-operator -o jsonpath="{.data.username}" | base64 -d)
+PORT=$(oc get secret example-postgres-sec -n cloud-resource-operator -o jsonpath="{.data.port}" | base64 -d)
+
+oc create secret generic system-database \
+    --from-literal=DB_PASSWORD="$PASSWORD" \
+    --from-literal=DB_USER="$USERNAME" \
+    --from-literal=URL=postgresql://"$USERNAME":"$PASSWORD"@"$HOST":"$PORT"/"$DATABASE" \
+    --namespace=3scale-test
+
+
+

--- a/setup_db.sh
+++ b/setup_db.sh
@@ -8,7 +8,7 @@
 # ./setup_db.sh
 
 # Outcome: 
-# CRO will create three redis and one posgres and secrets pointing to these db will be created in the 3scale-test ns
+# CRO will create three redis and one postgres and secrets pointing to these db will be created in the 3scale-test ns
 
 
 # Function to check if redis CR is available
@@ -90,9 +90,9 @@ done
                                                       
 # Kill the operator process
 pkill -f "main.go"
-# delete the cloud-resources-operator dir
+# delete the cloud-resource-operator dir
 cd ..
-rm -rf cloud-resources-operator
+rm -rf cloud-resource-operator
 
 
 # create the 3scale namespace
@@ -119,6 +119,3 @@ oc create secret generic system-database \
     --from-literal=DB_USER="$USERNAME" \
     --from-literal=URL=postgresql://"$USERNAME":"$PASSWORD"@"$HOST":"$PORT"/"$DATABASE" \
     --namespace=3scale-test
-
-
-


### PR DESCRIPTION
# What
Script to setup db external db in 3scale

# Issue
THREESCALE-10731

# Verification
- chmod and run the script against a fresh cluster
```bash
chmod 771 setup_db.sh
./setup_db.sh
```
- expected output
```bash
./setup_db.sh
Now using project "cloud-resource-operator" on server "https://api.aucunnin.w03b.s1.devshift.org:6443".

You can add applications to this project with the 'new-app' command. For example, try:

    oc new-app rails-postgresql-example

to build a new example application in Ruby. Or use kubectl to deploy a simple Kubernetes application:

    kubectl create deployment hello-node --image=k8s.gcr.io/e2e-test-images/agnhost:2.33 -- /agnhost serve-hostname

Already on project "cloud-resource-operator" on server "https://api.aucunnin.w03b.s1.devshift.org:6443".
serviceaccount/cloud-resource-operator created
clusterrole.rbac.authorization.k8s.io "manager-role" deleted
clusterrolebinding.rbac.authorization.k8s.io "manager-rolebinding" deleted
role.rbac.authorization.k8s.io/manager-role replaced
role.rbac.authorization.k8s.io/leader-election-role replaced
clusterrole.rbac.authorization.k8s.io/manager-role replaced
rolebinding.rbac.authorization.k8s.io/leader-election-rolebinding replaced
rolebinding.rbac.authorization.k8s.io/manager-rolebinding replaced
clusterrolebinding.rbac.authorization.k8s.io/manager-rolebinding replaced
service/operator-metrics-service replaced
oc new-project cloud-resource-operator || true
Error from server (AlreadyExists): project.project.openshift.io "cloud-resource-operator" already exists
oc label namespace cloud-resource-operator monitoring-key=middleware
namespace/cloud-resource-operator labeled
oc apply -f ./config/samples/cloud_resource_config.yaml -n cloud-resource-operator
configmap/cloud-resource-config created
oc apply -f ./config/samples/cloud_resources_openshift_strategies.yaml -n cloud-resource-operator
configmap/cloud-resources-openshift-strategies created
/usr/local/bin/kustomize build config/crd | oc apply -f -
customresourcedefinition.apiextensions.k8s.io/blobstorages.integreatly.org unchanged
customresourcedefinition.apiextensions.k8s.io/postgres.integreatly.org unchanged
customresourcedefinition.apiextensions.k8s.io/postgressnapshots.integreatly.org unchanged
customresourcedefinition.apiextensions.k8s.io/redis.integreatly.org unchanged
customresourcedefinition.apiextensions.k8s.io/redissnapshots.integreatly.org unchanged
redis.integreatly.org/redis-storage created
redis.integreatly.org/redis-queue created
redis.integreatly.org/redis-system created
postgres.integreatly.org/example-postgres created
One or both postgres conditions are not satisfied for example-postgres. Retrying in 10 seconds.
One or both postgres conditions are not satisfied for example-postgres. Retrying in 10 seconds.
One or both postgres conditions are not satisfied for example-postgres. Retrying in 10 seconds.
One or both postgres conditions are not satisfied for example-postgres. Retrying in 10 seconds.
One or both postgres conditions are not satisfied for example-postgres. Retrying in 10 seconds.
One or both postgres conditions are not satisfied for example-postgres. Retrying in 10 seconds.
One or both postgres conditions are not satisfied for example-postgres. Retrying in 10 seconds.
One or both postgres conditions are not satisfied for example-postgres. Retrying in 10 seconds.
Both postgres conditions are satisfied for example-postgres. Proceeding with the script.
./setup_db.sh: line 75: Check: command not found
Both redis conditions are satisfied for redis-storage. Proceeding with the script.
Both redis conditions are satisfied for redis-queue. Proceeding with the script.
Both redis conditions are satisfied for redis-system. Proceeding with the script.
Now using project "3scale-test" on server "https://api.aucunnin.w03b.s1.devshift.org:6443".

You can add applications to this project with the 'new-app' command. For example, try:

    oc new-app rails-postgresql-example

to build a new example application in Ruby. Or use kubectl to deploy a simple Kubernetes application:

    kubectl create deployment hello-node --image=k8s.gcr.io/e2e-test-images/agnhost:2.33 -- /agnhost serve-hostname

Creating secrets in the 3scale-test namespace
secret/system-redis created
secret/backend-redis created
secret/system-database created
```
- Outcome there is 3 redis created (redis-storage, redis-queue, redis-system) created
```bash
oc get redis --namespace=cloud-resource-operator
NAME            AGE
redis-queue     13m
redis-storage   13m
redis-system    12m
```
- Outcome there is 1 postgres created(example-postgres)
```bash
oc get postgres  --namespace=cloud-resource-operator
NAME               AGE
example-postgres   13m
```
- Outcome there will be 3 secrets created(system-redis,backend-redis,system-database)
```bash
oc get secrets --namespace=3scale-test | grep Opaque
backend-redis              Opaque                                2      7m38s
system-database            Opaque                                3      7m36s
system-redis               Opaque                                1      7m39s
```
- confirm that the contents of the secrets have correct connection url for the db
