### PR TITLE
THREESCALE-10742 add scripts to setup apimanager and monitoring stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,29 @@
 
 As series of scripts to automate preparing a cluster for Performance Testing
 - Databases
+- ApiManager(3scale)
+- Monitoring
 
 # Usage
 ## Databases Setup
+>**NOTE:** Script to be run before 3scale-operator is installed
 chmod and run the script against a fresh cluster
 ```bash
 chmod 771 setup_db.sh
 ./setup_db.sh
+```
+## ApiManager Setup
+`setup_apimanager.sh` script needs to be run after `setup_db.sh`
+chmod and run the script 
+```bash
+chmod 771 setup_apimanager.sh
+./setup_apimanager.sh
+```
+
+## Monitoring Setup
+`setup_monitoring.sh` script needs to be run after `setup_db.sh` and `setup_apimanager.sh`
+chmod and run the script 
+```bash
+chmod 771 setup_monitoring.sh
+./setup_monitoring.sh
 ```

--- a/setup_apimanager.sh
+++ b/setup_apimanager.sh
@@ -82,6 +82,8 @@ spec:
   sourceNamespace: openshift-marketplace
   startingCSV: dev-image-3scale-operator.0.0.1
 EOF
+# wait for CRD to be deployed
+sleep 30
 # create dummy S3 secret
 oc apply -f - <<EOF
 ---

--- a/setup_apimanager.sh
+++ b/setup_apimanager.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Prereq:
+# jq, oc, openshift cluster, ssh keys setup for github, operator-sdk, go1.19
+
+# Usage: 
+# chmod 771 setup_monitoring.sh
+# ./setup_apimanager.sh
+
+oc project 3scale-test
+# Install 3scale-operator via olm
+oc apply -f - <<EOF
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/3scale-operator.3scale-test: ''
+  name: 3scale-operator
+  namespace: 3scale-test
+spec:
+  channel: threescale-2.14
+  installPlanApproval: Automatic
+  name: 3scale-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: 3scale-operator.v0.11.10
+EOF
+
+# set the operator group to namespaces scope
+sleep 30
+OPERATORGROUP=$(oc get operatorGroup | grep 3scale | awk '{print $1}')
+oc patch operatorgroup "${OPERATORGROUP}" --type='json' -p='[{"op": "replace", "path": "/spec/targetNamespaces", "value": ["3scale-test"]}]'
+
+# create dummy S3 secret
+oc apply -f - <<EOF
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: s3-credentials
+data:
+  AWS_ACCESS_KEY_ID: UkVQTEFDRV9NRQ==
+  AWS_BUCKET: UkVQTEFDRV9NRQ==
+  AWS_REGION: UkVQTEFDRV9NRQ==
+  AWS_SECRET_ACCESS_KEY: UkVQTEFDRV9NRQ==
+type: Opaque
+EOF
+# Create Apimanager CR with monitoring enabled and system-database set to postgresql
+DOMAIN=$(oc get routes console -n openshift-console -o json | jq -r '.status.ingress[0].routerCanonicalHostname' | sed 's/router-default.//')
+oc apply -f - <<EOF
+---
+apiVersion: apps.3scale.net/v1alpha1
+kind: APIManager
+metadata:
+  name: apimanager-sample
+spec:
+  system:
+    monitoring:
+        enabled : true
+    database:
+        postgresql: {}
+    fileStorage:
+      simpleStorageService:
+        configurationSecretRef:
+          name: s3-credentials
+  wildcardDomain: $DOMAIN
+EOF
+# Check the install has completed for five minuits
+oc wait --for=condition=available apimanager/apimanager-sample --timeout=300s

--- a/setup_apimanager.sh
+++ b/setup_apimanager.sh
@@ -114,6 +114,6 @@ spec:
           name: s3-credentials
   wildcardDomain: $DOMAIN
 EOF
-# Check the install has completed for five minuits
-echo Check the install has completed for five minuits
+# Check the install has completed for five minutes
+echo Check the install has completed for five minutes
 oc wait --for=condition=available apimanager/apimanager-sample --timeout=300s

--- a/setup_monitoring.sh
+++ b/setup_monitoring.sh
@@ -57,6 +57,9 @@ spec:
   sourceNamespace: openshift-marketplace
   startingCSV: grafana-operator.v4.10.1
 EOF
+# patch apimanager CR monitoring enabled true
+sleep 30
+oc patch apimanager apimanager-sample --type='json' -p='[{"op": "add", "path": "/spec/monitoring", "value": {"enabled": true}}]'
 # Get the SECRET name that contains the THANOS_QUERIER_BEARER_TOKEN
 SECRET=`oc get secret -n openshift-user-workload-monitoring | grep  prometheus-user-workload-token | head -n 1 | awk '{print $1 }'`
 # Get the THANOS_QUERIER_BEARER_TOKEN using the SECRET name

--- a/setup_monitoring.sh
+++ b/setup_monitoring.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# Prereq:
+# jq, oc, openshift cluster, ssh keys setup for github, operator-sdk, go1.19
+
+# Usage: 
+# chmod 771 setup_monitoring.sh
+# ./setup_monitoring.sh
+
+git clone git@github.com:3scale/3scale-operator.git
+cd 3scale-operator/doc/monitoring-stack-deployment
+oc project 3scale-test
+# Create a subscription for prometheus operator
+oc apply -f - <<EOF
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: rhods-prometheus-operator
+  namespace: 3scale-test
+spec:
+  channel: beta
+  installPlanApproval: Automatic
+  name: rhods-prometheus-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: rhods-prometheus-operator.4.10.0
+EOF
+# Create a subscription for prometheus-exporter operator
+oc apply -f - <<EOF
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: prometheus-exporter-operator
+  namespace: 3scale-test
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: prometheus-exporter-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: prometheus-exporter-operator.v0.7.0
+EOF
+# Create Grafana Subscription
+oc apply -f - <<EOF
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: grafana-operator
+  namespace: 3scale-test
+spec:
+  channel: v4
+  installPlanApproval: Automatic
+  name: grafana-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: grafana-operator.v4.10.1
+EOF
+# Get the SECRET name that contains the THANOS_QUERIER_BEARER_TOKEN
+SECRET=`oc get secret -n openshift-user-workload-monitoring | grep  prometheus-user-workload-token | head -n 1 | awk '{print $1 }'`
+# Get the THANOS_QUERIER_BEARER_TOKEN using the SECRET name
+THANOS_QUERIER_BEARER_TOKEN=$(oc get secret $SECRET -n openshift-user-workload-monitoring -o jsonpath="{.data.token}" | base64 -d)
+# patch the THANOS_QUERIER_BEARER_TOKEN in the 3scale-scrape-configs.yaml
+sed -i "s|<THANOS_QUERIER_BEARER_TOKEN>|$THANOS_QUERIER_BEARER_TOKEN|g" 3scale-scrape-configs.yaml
+# create secret addition-scrape-configs from 3scale-scrape-configs.yaml file
+oc create secret generic additional-scrape-configs --from-file=3scale-scrape-configs.yaml=./3scale-scrape-configs.yaml
+
+# prometheus exporter 
+BKEND_REDIS_URL=$(oc get secret backend-redis -n 3scale-test -o jsonpath={.data.REDIS_QUEUES_URL} | base64 -d)
+BACKEND_REDIS_URL=$(echo "$BKEND_REDIS_URL" | sed 's|^redis://||; s|:6379$||')
+
+oc apply -n 3scale-test -f - <<EOF   
+---
+apiVersion: monitoring.3scale.net/v1alpha1
+kind: PrometheusExporter
+metadata:
+  name: backend-redis
+spec:
+  type: redis
+  grafanaDashboard:
+    label:
+      key: monitoring-key
+      value: middleware
+  extraLabel:
+    key: threescale_component
+    value: backend
+  dbHost: $BACKEND_REDIS_URL
+  dbPort: 6379
+  dbCheckKeys: "db1=resque:queue:stats,db1=resque:queue:priority,db1=resque:queue:main,db1=resque:failed,db1=resque:workers,db1=resque:queues"
+EOF
+# Prometheus CR
+DOMAIN=$(oc get routes console -n openshift-console -o json | jq -r '.status.ingress[0].routerCanonicalHostname' | sed 's/router-default.//')
+EXTERNALURL=https://prometheus.3scale-test.$DOMAIN
+sed -i "s|externalUrl:.*|externalUrl: $EXTERNALURL|" prometheus.yaml
+oc apply -f prometheus.yaml
+oc expose service prometheus-operated --hostname prometheus.3scale-test.$DOMAIN
+# Grafana CR's
+oc apply -f datasource.yaml
+oc apply -f grafana.yaml
+# remove 3scale-operator dir
+cd ../../../
+rm -rf 3scale-operator

--- a/setup_monitoring.sh
+++ b/setup_monitoring.sh
@@ -58,7 +58,7 @@ spec:
   startingCSV: grafana-operator.v4.10.1
 EOF
 # patch apimanager CR monitoring enabled true
-sleep 30
+sleep 60
 oc patch apimanager apimanager-sample --type='json' -p='[{"op": "add", "path": "/spec/monitoring", "value": {"enabled": true}}]'
 # Get the SECRET name that contains the THANOS_QUERIER_BEARER_TOKEN
 SECRET=`oc get secret -n openshift-user-workload-monitoring | grep  prometheus-user-workload-token | head -n 1 | awk '{print $1 }'`
@@ -97,7 +97,7 @@ DOMAIN=$(oc get routes console -n openshift-console -o json | jq -r '.status.ing
 EXTERNALURL=https://prometheus.3scale-test.$DOMAIN
 sed -i "s|externalUrl:.*|externalUrl: $EXTERNALURL|" prometheus.yaml
 oc apply -f prometheus.yaml
-oc wait --for=condition=available prometheus/example --timeout=-1s
+sleep 5
 oc expose service prometheus-operated --hostname prometheus.3scale-test.$DOMAIN
 # Grafana CR's
 oc apply -f datasource.yaml

--- a/setup_monitoring.sh
+++ b/setup_monitoring.sh
@@ -97,6 +97,7 @@ DOMAIN=$(oc get routes console -n openshift-console -o json | jq -r '.status.ing
 EXTERNALURL=https://prometheus.3scale-test.$DOMAIN
 sed -i "s|externalUrl:.*|externalUrl: $EXTERNALURL|" prometheus.yaml
 oc apply -f prometheus.yaml
+oc wait --for=condition=available prometheus/example --timeout=-1s
 oc expose service prometheus-operated --hostname prometheus.3scale-test.$DOMAIN
 # Grafana CR's
 oc apply -f datasource.yaml


### PR DESCRIPTION
# What
Scripts to setup apimanager and the monitoring stack

# Issue
[THREESCALE-10742](https://issues.redhat.com/browse/THREESCALE-10742)

# Verification

Run the setup_db.sh script to prepare the DB
```bash
./setup_db.sh
```
- chmod and run `setup_apimanager.sh` script
```bash
chmod 771 setup_apimanager.sh
./setup_apimanager.sh
```
- Outcome 3scale is install with monitoring enabled and system-database postgresql
chmod and run the setup_monitoring.sh script 
```bash
chmod 771 setup_monitoring.sh
./setup_monitoring.sh
```
- outcome is that prometheus with the 3scale alerts 
![image](https://github.com/3scale-labs/3scale-perf-setup/assets/16667688/86f91138-65bb-425a-8a27-9379ee9b10fe)

- Also grafana will be installed and grafana will have the prometheus-exporter dashboard along with the standard dashboards.

![image](https://github.com/3scale-labs/3scale-perf-setup/assets/16667688/712bba7d-6190-4724-9475-e928faa86431)
