### PR TITLE
Add an alert check script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 perf-test-*
 .idea/
+threescale-alert-*

--- a/README.md
+++ b/README.md
@@ -41,3 +41,58 @@ chmod and run the script
 chmod 771 setup_product.sh
 ./setup_product.sh
 ```
+
+## Caputure Resource Metrics
+This script requires 2 files containing the start and end times generated with `date -u +%Y-%m-%dT%TZ > perf-test-start-time.txt` and `date -u +%Y-%m-%dT%TZ > perf-test-end-time.txt` respectlively 
+- a "perf-test-start-time.txt" file with a valid rfc3339 timestamp from a moment before performance tests started 
+- a "perf-test-end-time.txt" file with a valid rfc3339 timestamp from a moment after performance tests finished
+
+`capture_resource-metrics.sh`
+
+```bash
+chmod 771 capture_resource-metrics.sh
+./capture_resource_metrics.sh
+64
+32
+31.64
+277.05847930908203
+122.5894775390625
+110.1988525390625
+4.415
+5287.2557373046875
+4215.2372829861115
+0.09181629062352627
+0.09181629062352627
+4521.91015625
+0.09843198155966482
+0.09843198155966482
+```
+
+You can copy the output to our google [spreadsheet](https://docs.google.com/spreadsheets/d/1HV577_tQ_f-HRcIN9zYBB6sSIpYo04DSiQMqYe1hEds/edit#gid=0) where it will be formated
+
+## Alerts Check
+This script can be run at the start of a test run and it will capture any alerts or pending alerts while running, at the end of the run hit  Ctrl C to exit
+
+```
+chmod 771 alert_check.sh
+./alert_check.sh
+No alert firing
+Tue 07 May 2024 14:46:17 IST
+
+=================== Sleeping for 5 seconds ======================
+
+No alert firing
+Tue 07 May 2024 14:46:23 IST
+
+=================== Sleeping for 5 seconds ======================
+
+^C
+
+```
+While running it will generate and update two files which will capture any alerts that fire or go pending
+```bash
+threescale-alert-firing-2024-05-07-14-46-report.csv
+threescale-alert-pending-2024-05-07-14-46-report.csv
+```
+
+

--- a/alert_check.sh
+++ b/alert_check.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# USAGE
+# ./alerts-check.sh <optional sleep in seconds>
+# ^C to break
+# Generates two files one for firing and one for pending alerts
+#
+# PREREQUISITES
+# - jq
+# - oc (logged in at the cmd line in order to get the bearer token)
+# VARIABLES
+
+SLEEP_TIME="${1-5}"
+REPORT_TIME=$(date +"%Y-%m-%d-%H-%M")
+ROUTE="http://localhost:9090/api/v1/alerts"
+TOKEN=$(oc whoami --show-token)
+# wait for monitoring route to appear and have host populated
+until oc exec -n "3scale-test" "prometheus-example-0" -- curl -sS -H "Accept: application/json" -H "Authorization: Bearer $TOKEN" -k "$ROUTE" &> /dev/null
+do
+    echo "Waiting for 3scale-test pods to be available. Next check in 1 minute."
+    sleep 60
+done
+
+# Define an array of monitoring data sources
+declare -A monitoring_sources=(
+  ["threescale"]="{}"
+)
+
+
+# Define an array of alert states to report on
+declare -a alert_states=("pending" "firing")
+
+# remove tmp files on ctrl-c
+trap 'find . -name "tmp-*" -delete; for source_name in "${!monitoring_sources[@]}"; do for alert_state in "${alert_states[@]}"; do if [[ -f "tmp-${source_name}-alert-${alert_state}-${REPORT_TIME}-report.csv" ]]; then rm "tmp-${source_name}-alert-${alert_state}-${REPORT_TIME}-report.csv"; fi; done; done' EXIT
+
+# function to check if there are no alerts firing bar deadmansnitch
+function CHECK_NO_ALERTS() {
+
+  THREESCALE_MONITORING=$(oc exec -n "3scale-test" "prometheus-example-0" -- curl -sS -H "Accept: application/json" -H "Authorization: Bearer $TOKEN" -k "$ROUTE")
+  monitoring_sources["threescale"]=$THREESCALE_MONITORING
+
+  # Extract firing alerts from THREESCALE monitoring
+  threescale_alerts=$(echo "$THREESCALE_MONITORING" | jq -r '.data.alerts[] | select(.state == "firing") | [.labels.alertname, .state, .activeAt, .labels.severity] | @csv')
+
+  # Extract pending alerts from THREESCALE monitoring
+  threescale_alerts_pending=$(echo "$THREESCALE_MONITORING" | jq -r '.data.alerts[] | select(.state == "pending") | [.labels.alertname, .state, .activeAt, .labels.severity] | @csv')
+
+  # Check if there are no firing alerts
+  if [[ $(echo "$threescale_alerts" | wc -l | xargs) == 1 ]]; then
+    echo No alert firing
+    date
+  elif [[ $(echo "$threescale_alerts" | wc -l | xargs) != 1 ]]; then
+    echo "============================================================================"
+    date
+    echo "----------------------------------------------------------------------------"
+    echo "Following alerts are firing for 3scale-test:"
+    echo "$threescale_alerts"
+    echo "============================================================================"
+    echo "Following alerts are pending for 3scale-test:"
+    echo "$threescale_alerts_pending"
+    echo "============================================================================"
+  fi
+}
+
+
+#If no product is passed in then run for all products
+if [[ "$2" == "" ]]; then
+  while :; do
+
+    CHECK_NO_ALERTS
+
+    # Loop over each monitoring source
+    for source_name in "${!monitoring_sources[@]}"; do
+      source_data="${monitoring_sources[$source_name]}"
+
+      # Loop over each alert state to report on
+      for alert_state in "${alert_states[@]}"; do
+        # Generate a report for the current alert state and monitoring source
+        echo "$source_data" |
+          jq -r --arg state "$alert_state" '.data.alerts[] | select(.state==$state) | [.labels.alertname, .state, .activeAt, .labels.severity] | @csv' >> "${source_name}-alert-${alert_state}-${REPORT_TIME}-report.csv"
+
+        # Sort the report to remove duplicates
+        sort -t',' -k 1,1 -u "${source_name}-alert-${alert_state}-${REPORT_TIME}-report.csv" -o "${source_name}-alert-${alert_state}-${REPORT_TIME}-report.csv"
+      done
+    done
+
+    echo -e "\n=================== Sleeping for $SLEEP_TIME seconds ======================\n"
+    sleep $SLEEP_TIME
+    # If the above sleep failed sleep for 5 seconds (default)
+    if [[ $? != 0 ]]; then
+      sleep 5
+    fi
+  done
+fi


### PR DESCRIPTION
# What
script for checking alerts firing during run

# Verify 
This script can be run at the start of a test run and it will capture any alerts or pending alerts while running, at the end of the run hit  Ctrl C to exit

```
chmod 771 alert_check.sh
./alert_check.sh
No alert firing
Tue 07 May 2024 14:46:17 IST

=================== Sleeping for 5 seconds ======================

No alert firing
Tue 07 May 2024 14:46:23 IST

=================== Sleeping for 5 seconds ======================

^C

```
While running it will generate and update two files which will capture any alerts that fire or go pending
```bash
threescale-alert-firing-2024-05-07-14-46-report.csv
threescale-alert-pending-2024-05-07-14-46-report.csv
```